### PR TITLE
Fix issue with duplication of clock widget

### DIFF
--- a/src/main/kotlin/clock/Registration.kt
+++ b/src/main/kotlin/clock/Registration.kt
@@ -1,7 +1,9 @@
 package clock
 
+import com.intellij.diagnostic.IdeMessagePanel
 import com.intellij.openapi.components.ProjectComponent
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.StatusBar
 import com.intellij.openapi.wm.WindowManager
 
 class Registration(private val project: Project) : ProjectComponent {
@@ -11,6 +13,10 @@ class Registration(private val project: Project) : ProjectComponent {
         WindowManager
             .getInstance()
             .getStatusBar(project)
-            ?.addWidget(Widget(), "before FatalError")
+            ?.addWidget(
+                Widget(),
+                StatusBar.Anchors.before(IdeMessagePanel.FATAL_ERROR),
+                project
+            )
     }
 }


### PR DESCRIPTION
- The old widget were not removed by its `Registration`, so it remained on the status bar along with the new widget
- `addWidget` takes `parentDisposable: Disposable` argument; as soon as `parentDisposable` will be disposed by the IDE (in this case, when project will be closed), the widget will be removed from the status bar
- Overriding of `projectClosed` and removing widget there did not succeed, because for some reason `getStatusBar` returns null during project closing
- Also, replace anchor string literal with constant defined in `IdeMessagePanel`
- Fixes #1